### PR TITLE
Remove 'uberfire-extensions' from 'repository-list-master'

### DIFF
--- a/src/main/resources/repository-list-master.txt
+++ b/src/main/resources/repository-list-master.txt
@@ -1,5 +1,4 @@
 uberfire/uberfire
-uberfire/uberfire-extensions
 dashbuilder/dashbuilder
 droolsjbpm/droolsjbpm-build-bootstrap
 droolsjbpm/droolsjbpm-knowledge

--- a/src/test/java/org/kie/jenkinsci/plugins/kieprbuildshelper/GitHubRepositoryListTest.java
+++ b/src/test/java/org/kie/jenkinsci/plugins/kieprbuildshelper/GitHubRepositoryListTest.java
@@ -26,9 +26,9 @@ public class GitHubRepositoryListTest {
     @Test
     public void shouldSuccessfullyLoadListForMaster() {
         GitHubRepositoryList repoList = GitHubRepositoryList.fromClasspathResource(GitHubRepositoryList.KIE_REPO_LIST_MASTER_RESOURCE_PATH);
-        Assert.assertEquals(24, repoList.size());
+        Assert.assertEquals(23, repoList.size());
         Assert.assertEquals(new KieGitHubRepository("uberfire", "uberfire"), repoList.getList().get(0));
-        Assert.assertEquals(new KieGitHubRepository("jboss-integration", "kie-eap-modules"), repoList.getList().get(23));
+        Assert.assertEquals(new KieGitHubRepository("jboss-integration", "kie-eap-modules"), repoList.getList().get(22));
     }
 
     @Test (expected = IllegalArgumentException.class)


### PR DESCRIPTION
'uberfire-extensions' was moved directly into uberfire repository.